### PR TITLE
fix: use newer quart API, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,18 @@ receives push events all it takes is:
 from quart_github_webhook import Webhook
 from quart import Quart
 
-app = Quart(__name__)  # Standard Flask app
-webhook = Webhook(app) # Defines '/postreceive' endpoint
+app = Quart(__name__)  # Standard Flask app, using Quart
+
+# Defines the '/postreceive' endpoint
+# you can also specify here: a github secret token, or a different endpoint URL
+webhook = Webhook(app)
 
 @app.route("/")        # Standard Flask endpoint
 async def hello_world():
     return "Hello, World!"
 
-@webhook.hook()        # Defines a handler for the 'push' event
-async def on_push(data):
+@webhook.hook("push")        # Defines a handler for the 'push' event
+async def on_push_event_receieved(data):
     print("Got push with: {0}".format(data))
 
 if __name__ == "__main__":

--- a/quart_github_webhook/webhook.py
+++ b/quart_github_webhook/webhook.py
@@ -3,6 +3,7 @@ import hashlib
 import hmac
 import logging
 import json
+import asyncio
 from quart import abort, request
 
 
@@ -35,6 +36,9 @@ class Webhook(object):
         """
 
         def decorator(func):
+            if not asyncio.iscoroutinefunction(func):
+                raise ValueError("Webhook callback for '{0}' must be marked 'async'".format(event_type))
+                
             self._hooks[event_type].append(func)
             return func
 

--- a/quart_github_webhook/webhook.py
+++ b/quart_github_webhook/webhook.py
@@ -17,7 +17,7 @@ class Webhook(object):
 
     def __init__(self, app, endpoint="/postreceive", secret=None):
         app.add_url_rule(
-            path=endpoint, endpoint=endpoint, view_func=self._postreceive, methods=["POST"],
+            rule=endpoint, endpoint=endpoint, view_func=self._postreceive, methods=["POST"],
         )
 
         self._hooks = collections.defaultdict(list)


### PR DESCRIPTION
- fixes https://github.com/go-build-it/quart-github-webhook/issues/2 credit to @NargiT for the fix
- update the example in the README to provide the required "push" param

Tested locally, seems to work ok, haven't run any serious tests or anything on it.